### PR TITLE
Nginx: double user on user line (adding www-data group also)

### DIFF
--- a/files/etc/nginx/nginx.conf
+++ b/files/etc/nginx/nginx.conf
@@ -1,6 +1,6 @@
 # MANAGED VIA SALT --  DO NOT EDIT
 {% set data=salt['mc_nginx.settings']() %}
-user {{data.user}};
+user {{data.user}} {{data.user}};
 worker_processes {{data.worker_processes}};
 worker_rlimit_nofile {{data.ulimit}};
 {% if data.get('no_daemon', False) %}


### PR DESCRIPTION
Currently we have:

```
user www-data;
```

With:

```
    user www-data www-data;
```

I can have nginx accessing the php-fpm socket (which have the www-data group).
This is a small fix in a bigger reduce-list-of-groups-for-users list of fixs.
