### PR TITLE
Nginx: double user on user line (adding www-data group also)

### DIFF
--- a/files/etc/nginx/nginx.conf
+++ b/files/etc/nginx/nginx.conf
@@ -1,6 +1,6 @@
 # MANAGED VIA SALT --  DO NOT EDIT
 {% set data=salt['mc_nginx.settings']() %}
-user {{data.user}};
+user {{data.user}} {{data.group}};
 worker_processes {{data.worker_processes}};
 worker_rlimit_nofile {{data.ulimit}};
 {% if data.get('no_daemon', False) %}

--- a/mc_states/modules/mc_nginx.py
+++ b/mc_states/modules/mc_nginx.py
@@ -110,6 +110,8 @@ def settings():
         IGH:!aNULL:!MD5
     user
         nginx user
+    group
+        nginx group
     server_names_hash_bucket_size
         raw setting for nginx (see nginx documentation)
     loglevel
@@ -273,6 +275,7 @@ def settings():
                 'worker_connections': '1024',
                 'multi_accept': True,
                 'user': 'www-data',
+                'group': 'www-data',
                 'server_names_hash_bucket_size': '64',
                 'loglevel': 'crit',
                 'ldap_cache': True,


### PR DESCRIPTION
Currently we have:

```
user www-data;
```

With:

```
user www-data www-data;
```

I was able to fix problems on socket access, in case nginx user was not
member of php-fpm group (which is not the default case).

At least this add the ability to override nginx group.
