### PR TITLE
BUG: Nginx forwarded_server_port default map value wasn't set because…

### DIFF
--- a/files/etc/nginx/nginx.conf
+++ b/files/etc/nginx/nginx.conf
@@ -178,7 +178,7 @@ http {
         https on;
     }
     map $http_x_ssl $forwarded_server_port {
-        default: $server_port;
+        default $server_port;
         1 443;
     }
 


### PR DESCRIPTION
… of extra ':'
