### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Paas made easy with saltstack, ansible and makina-states
 About
 ------
 
-Please go to this [documentation](http://makina-states.readthedocs.org).
+Please go to this [documentation](https://makina-states.readthedocs.io).
 
 | branch  | coverage status                                                                                                                                                      |  build status                                                                                                                                    |
 |---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/doc/v1/ref_formulaes/services/monitoring/circus.rst
+++ b/doc/v1/ref_formulaes/services/monitoring/circus.rst
@@ -3,7 +3,7 @@ Circus configuration
 
 Circus_ is a Python program which can be used to monitor and control processes and sockets.
 
-.. _Circus: http://circus.readthedocs.org/en/latest/
+.. _Circus: https://circus.readthedocs.io/en/latest/
 
 Exposed Hooks:
   circus-pre-restart


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
